### PR TITLE
Limpet and Vehicle Durability Overhaul

### DIFF
--- a/examples/weapon/_Weapon595_Limpet-Splendor.json
+++ b/examples/weapon/_Weapon595_Limpet-Splendor.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 6
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.9
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 90
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.0
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.25
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 93
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_normal"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 475
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 210
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スプレンダー"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スプレンダー"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon595",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 6x30\n     Shrapnel: 1.50sec/100% Speed/25% Size\n     Reload: 3.5sec\n     Fire Rate: 0.65/sec\n     Range: 475m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is a direct-to-manufacture model based on the original prototype.  While unrefined compared to later models, it is cheap to build enmass and has a proven record against the Giant Insects 8 years ago."
+  }
+}

--- a/examples/weapon/_Weapon596_Limpet-Sniper.json
+++ b/examples/weapon/_Weapon596_Limpet-Sniper.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 2
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0.5
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 300
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 8
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 4
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 5
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 120
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombSnipe_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.6000000238418579
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 900
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 360
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/mark_snp.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_sniper01.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_sniper01.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_sniper01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABwAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAcAIAAHwCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAAB2AgAAigIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAA4gIAAAAAAAC8AAAA7AAAAMICAAABAAAAzAAAAOwAAACqAgAAAQAAANwAAADsAAAAlAIAAAEAAADcAgAAAAAAQQAAAAAQAgAA3AIAAAAAAAAAAAAAYAEAANwCAAAAAJBBAAAAALABAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MFVci5UAAAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MM5TDX0AAAAAMAAxAAAASQBLAAAAYgBhAHIAcgBlAGwAAABiAG8AZAB5AAAAcgBlAGwAbwBhAGQAXwBlAG4AZAAAAHIAZQBsAG8AYQBkAF8AbABvAG8AcAAAAHIAZQBsAG8AYQBkAF8AcwB0AGEAcgB0AAAAcwBlAAAAcwB0AGEAbgBkAGIAeQAAAA=="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スナイプガン"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Sniper"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スナイプガン"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon596",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 300\n     Blast Area: Radius 8m\n     Reload: 6.0sec\n     Fire Rate: 0.5/sec\n     Range: 900m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nAdapted from standard issue Ranger sniper platforms such as the 'Stringer' the Limpet Sniper series of Limpet Launchers has superior range and velocity. It even fires a larger caliber of Limpet allowing for devastating point strikes at extreme range.  However this drastically limits the amount of ammo the weapon can load in it's internal magazine.  That combined with the issues of loading the larger limpets means this series of Limpet launchers has poor ammo capacity and reload speed, hurting its flexibility at closer ranges.\n\nThis version is a direct-to-manufacture model based on the original prototype.  While unrefined compared to later models, it is cheap to build enmass and has a proven record against the Giant Insects 8 years ago."
+  }
+}

--- a/examples/weapon/_Weapon597_Limpet-Gun-D.json
+++ b/examples/weapon/_Weapon597_Limpet-Gun-D.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 200
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 6.25
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.86
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 82
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBomb_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.6309999823570251
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 465
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 210
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペットガンＤ"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Gun D"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペットガンＤ"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon597",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 200\n     Blast Area: Radius 6.25m\n     Reload: 3.45sec\n     Fire Rate: 0.73/sec\n     Range: 465m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis is an enhanced model compared to the original design featuring overall better performance."
+  }
+}

--- a/examples/weapon/_Weapon598_Limpet-Splendor-D.json
+++ b/examples/weapon/_Weapon598_Limpet-Splendor-D.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 12
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.91
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 95
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.05
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.26
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 90
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_normal"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 485
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 207
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スプレンダーＤ"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor D"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スプレンダーＤ"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon598",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 12x30\n     Shrapnel: 1.58sec/105% Speed/0.26% Size\n     Reload: 3.45sec\n     Fire Rate: 0.67/sec\n     Range: 485m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is an enhanced model compared to the original design featuring overall better performance."
+  }
+}

--- a/examples/weapon/_Weapon599_Limpet-Gun-M2.json
+++ b/examples/weapon/_Weapon599_Limpet-Gun-M2.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 400
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 6.5
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.87
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 79
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombM2_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 480
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 204
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペットガンＭ２"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Gun M2"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペットガンＭ２"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon599",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 400\n     Blast Area: Radius 6.5m\n     Reload: 3.4sec\n     Fire Rate: 0.76/sec\n     Range: 480m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis is the Mark 2 version featuring greatly improved performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon600_Limpet-Sniper-D.json
+++ b/examples/weapon/_Weapon600_Limpet-Sniper-D.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 4
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 2
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 900
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 8.25
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 4
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 6
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 120
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombSnipeD_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 960
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 351
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/mark_snp.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_sniper01.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_sniper01.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_sniper01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABwAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAcAIAAHwCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAAB2AgAAigIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAA4gIAAAAAAAC8AAAA7AAAAMICAAABAAAAzAAAAOwAAACqAgAAAQAAANwAAADsAAAAlAIAAAEAAADcAgAAAAAAQQAAAAAQAgAA3AIAAAAAAAAAAAAAYAEAANwCAAAAAJBBAAAAALABAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MFVci5UAAAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MM5TDX0AAAAAMAAxAAAASQBLAAAAYgBhAHIAcgBlAGwAAABiAG8AZAB5AAAAcgBlAGwAbwBhAGQAXwBlAG4AZAAAAHIAZQBsAG8AYQBkAF8AbABvAG8AcAAAAHIAZQBsAG8AYQBkAF8AcwB0AGEAcgB0AAAAcwBlAAAAcwB0AGEAbgBkAGIAeQAAAA=="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スナイプガンＤ"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Sniper D"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スナイプガンＤ"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon600",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 900\n     Blast Area: Radius 8.25m\n     Reload: 5.85sec\n     Fire Rate: 0.5/sec\n     Range: 960m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nAdapted from standard issue Ranger sniper platforms such as the 'Stringer' the Limpet Sniper series of Limpet Launchers has superior range and velocity. It even fires a larger caliber of Limpet allowing for devastating point strikes at extreme range.  However this drastically limits the amount of ammo the weapon can load in it's internal magazine.  That combined with the issues of loading the larger limpets means this series of Limpet launchers has poor ammo capacity and reload speed, hurting its flexibility at closer ranges.\n\nThis is an enhanced model compared to the original design featuring overall better performance."
+  }
+}

--- a/examples/weapon/_Weapon601_Limpet-Splendor-M2.json
+++ b/examples/weapon/_Weapon601_Limpet-Splendor-M2.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 26
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.92
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 100
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.10
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.27
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 87
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_splenderM2"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 495
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 204
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スプレンダーＭ２"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor M2"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スプレンダーＭ２"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon601",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 26x30\n     Shrapnel: 1.66sec/110% Speed/27% Size\n     Reload: 3.40sec\n     Fire Rate: 0.69/sec\n     Range: 495m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 2 version featuring greatly improved performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon602_Limpet-Launcher.json
+++ b/examples/weapon/_Weapon602_Limpet-Launcher.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 2500
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 15
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1.25
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_M"
+        },
+        {
+          "type": "float",
+          "value": 0.8913000226020813
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_grenade.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 8
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.5
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾大着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 60
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombLauncher_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 300
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 600
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・ランチャー"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Launcher"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・ランチャー"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_grenade.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon602",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 1\n     Damage: 2500\n     Blast Area: Radius 15m\n     Reload: 10sec\n     Fire Rate: 1/sec\n     Range: 300m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Heavy Limpet Launcher is a series of experimental Sniper Limpet Launchers which have completely sacrificed range and velocity in pursuit of loading the single largest Limpet possible.  The result is a devastating superweapon that places the power of the C line of explosives in the standard Limpet Launcher package.  However the weapon is entirely adapted around fitting only a single limpet.  On top of that it's so large and cumbersome to load that this variety of Limpet Launcher has by far the slowest reload time.  An acceptable downside for having the power of a small airstrike in a single gun.\n\nThis version is a direct-to-manufacture model based on the original prototype.  While unrefined compared to later models, it is cheap to build enmass and has a proven record against the Giant Insects 8 years ago."
+  }
+}

--- a/examples/weapon/_Weapon603_Limpet-Splendor-A30.json
+++ b/examples/weapon/_Weapon603_Limpet-Splendor-A30.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 30
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 24
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.93
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 3
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 105
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.15
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.28
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0.05000000074505806
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 84
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_splenderA30"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 505
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 390
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スプレンダーＡ３０"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor A30"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スプレンダーＡ３０"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon603",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 30\n     Damage: 24x30\n     Shrapnel: 1.75sec/115% Speed/28% Size\n     Reload: 6.5sec\n     Fire Rate: 0.71/sec\n     Range: 505m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is a modified Splendor M2 made compatible with an extremely large extended magazine resulting in a colossal 30 Limpet capacity.  However the new magazine is unwieldy to work with and nearly doubles the time needed to reload.  An excellent weapon for setting elaborate traps, the full 30 detonations making quite the fireworks show."
+  }
+}

--- a/examples/weapon/_Weapon604_Limpet-Gun-M3.json
+++ b/examples/weapon/_Weapon604_Limpet-Gun-M3.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 140
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 6.25
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.88
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾大着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0.11999999731779099
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 3
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 96
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombM3_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 150
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 261
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リンペットショット"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Shot"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リンペットショット"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon604",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 140x3\n     Blast Area: Radius 6.25m\n     Reload: 4.35sec\n     Fire Rate: 0.63/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant."
+  }
+}

--- a/examples/weapon/_Weapon605_Splendor-Shot.json
+++ b/examples/weapon/_Weapon605_Splendor-Shot.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 14
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.94
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 110
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.20
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.29
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0.11999999731779099
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 5
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 100
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.30000001192092896
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_spread"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 160
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 228
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "スプレンダー・ショット"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Splendor Shot"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "スプレンダー・ショット"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon605",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 14x5x30\n     Shrapnel: 1.83sec/120% Speed/29% Size\n     Reload: 3.8sec\n     Fire Rate: 0.6/sec\n     Range: 160m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis 'Shot' version however has been modified to fire 5 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 4 additional shots provide more damage and coverage than the standard Splendor variant."
+  }
+}

--- a/examples/weapon/_Weapon606_Limpet-Splendor-M3.json
+++ b/examples/weapon/_Weapon606_Limpet-Splendor-M3.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 40
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_M"
+        },
+        {
+          "type": "float",
+          "value": 0.8913000226020813
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.95
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 115
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.25
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.30
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 78
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_splenderM3"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 525
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 195
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スプレンダーＭ３"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor M3"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スプレンダーＭ３"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon606",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 40x30x8\n     Shrapnel: 1.91sec/125% Speed/30% Size\n     Reload: 3.25sec\n     Fire Rate: 0.77/sec\n     Range: 525m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 3 version featuring hugely improved performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon607_Limpet-Chain-Gun.json
+++ b/examples/weapon/_Weapon607_Limpet-Chain-Gun.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 6
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 860
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.84
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 40
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombR_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 0.943880021572113
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 300
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 318
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・チェーンガン"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Chain Gun"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・チェーンガン"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon607",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 6\n     Damage: 860\n     Blast Area: Radius 5m\n     Reload: 5.3sec\n     Fire Rate: 1.5/sec\n     Range: 300m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThe Chaingun variety is a heavily modified version: The loading mechanism was completely overhauled to accept small belt-fed magazines of Limpets, the result being a dramatic improvement in fire rate over the other Limpet Launchers.  However to achieve this smaller but higher grade limpets were used, resulting in lower velocity shots that cause smaller but equally intense explosions.  The new magazine is also tricky to install and has extended loading times significantly as a result.  Overall the weapon is capable of outputting much more damage than the average Limpet Gun, but loses some of its flexibility and is far more expensive to produce limiting it to special forces use only."
+  }
+}

--- a/examples/weapon/_Weapon608_Limpet-Sniper-A3.json
+++ b/examples/weapon/_Weapon608_Limpet-Sniper-A3.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 4
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 2
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 1600
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 8.50
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 7
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 120
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombSnipeD_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 1020
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 342
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/mark_snp.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_sniper01.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_sniper01.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_sniper01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABwAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAcAIAAHwCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAAB2AgAAigIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAA4gIAAAAAAAC8AAAA7AAAAMICAAABAAAAzAAAAOwAAACqAgAAAQAAANwAAADsAAAAlAIAAAEAAADcAgAAAAAAQQAAAAAQAgAA3AIAAAAAAAAAAAAAYAEAANwCAAAAAJBBAAAAALABAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MFVci5UAAAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MM5TDX0AAAAAMAAxAAAASQBLAAAAYgBhAHIAcgBlAGwAAABiAG8AZAB5AAAAcgBlAGwAbwBhAGQAXwBlAG4AZAAAAHIAZQBsAG8AYQBkAF8AbABvAG8AcAAAAHIAZQBsAG8AYQBkAF8AcwB0AGEAcgB0AAAAcwBlAAAAcwB0AGEAbgBkAGIAeQAAAA=="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スナイプガンＡ３"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Sniper A3"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スナイプガンＡ３"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon608",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 1600\n     Blast Area: Radius 8.5m\n     Reload: Xsec\n     Fire Rate: 5.70/sec\n     Range: 1020m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nAdapted from standard issue Ranger sniper platforms such as the 'Stringer' the Limpet Sniper series of Limpet Launchers has superior range and velocity. It even fires a larger caliber of Limpet allowing for devastating point strikes at extreme range.  However this drastically limits the amount of ammo the weapon can load in it's internal magazine.  That combined with the issues of loading the larger limpets means this series of Limpet launchers has poor ammo capacity and reload speed, hurting its flexibility at closer ranges.\n\nThis version is a greatly enhanced version of the D model that also loads an additional Limpet thanks to an improvement in Limpet yield efficiency resulting in the downscaling of the Limpet's caliber while still improving its destructive capability."
+  }
+}

--- a/examples/weapon/_Weapon609_Limpet-Detector.json
+++ b/examples/weapon/_Weapon609_Limpet-Detector.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 52
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_M"
+        },
+        {
+          "type": "float",
+          "value": 0.8913000226020813
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.96
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 120
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.30
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.31
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 75
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_splenderM3"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 535
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 192
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スプレンダーＭ4"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor M4"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スプレンダーＭ4"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon609",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 52x30\n     Shrapnel: 2sec/130% Speed/31% Size\n     Reload: 3.2sec\n     Fire Rate: 0.8/sec\n     Range: 525m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 4 version featuring colossally improved performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon610_Limpet-Shot.json
+++ b/examples/weapon/_Weapon610_Limpet-Shot.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 340
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 6.75
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.9
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾大着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0.11999999731779099
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 3
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 90
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.6000000238418579
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombSpread_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 165
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 255
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・ショットM2"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Shot M2"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・ショットM2"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon610",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 340x3\n     Blast Area: Radius 6.75m\n     Reload: 4.25sec\n     Fire Rate: 0.67/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis improved 'Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant."
+  }
+}

--- a/examples/weapon/_Weapon611_Limpet-Buster.json
+++ b/examples/weapon/_Weapon611_Limpet-Buster.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 340
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 6.75
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.9
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾大着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 70
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombR_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 0.943880021572113
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 459
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 198
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・バスター"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Gun M5"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・バスター"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon611",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 1600\n     Blast Area: Radius 7m\n     Reload: 3.3sec\n     Fire Rate: 0.86/sec\n     Range: 450m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis is the Mark 3 version featuring hugely improved performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon612_Limpet-Splendor-M9.json
+++ b/examples/weapon/_Weapon612_Limpet-Splendor-M9.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 66
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_M"
+        },
+        {
+          "type": "float",
+          "value": 0.8913000226020813
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.97
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 125
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.35
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.32
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 72
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_splenderM9"
+        },
+        {
+          "type": "float",
+          "value": 0.5299999713897705
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 545
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 189
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スプレンダーＭ９"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor M9"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スプレンダーＭ９"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon612",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 66x30\n     Shrapnel: 2.08sec/135% Speed/0.32% Size\n     Reload: 3.15sec\n     Fire Rate: 0.83/sec\n     Range: 545m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThe Mark 9 had a troubled history: between it and the Mark 4 many prototypes failed to produce the results needed, almost resulting in the project being scrapped.  A breakthrough in Ravager based alloy technology finally meant the Mark 9 could produce shrapnel sharper than ever before from an explosive device while also making improvements to the launcher's performance in every other area."
+  }
+}

--- a/examples/weapon/_Weapon613_Limpet-Sniper-F3.json
+++ b/examples/weapon/_Weapon613_Limpet-Sniper-F3.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 4
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 2
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 6800
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 17.5
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1.25
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 8
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.65
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 60
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombSnipeF3_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5623000264167786
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 450
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 600
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/mark_snp.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_sniper01.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_sniper01.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_sniper01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABwAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAcAIAAHwCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAAB2AgAAigIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAA4gIAAAAAAAC8AAAA7AAAAMICAAABAAAAzAAAAOwAAACqAgAAAQAAANwAAADsAAAAlAIAAAEAAADcAgAAAAAAQQAAAAAQAgAA3AIAAAAAAAAAAAAAYAEAANwCAAAAAJBBAAAAALABAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MFVci5UAAAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MM5TDX0AAAAAMAAxAAAASQBLAAAAYgBhAHIAcgBlAGwAAABiAG8AZAB5AAAAcgBlAGwAbwBhAGQAXwBlAG4AZAAAAHIAZQBsAG8AYQBkAF8AbABvAG8AcAAAAHIAZQBsAG8AYQBkAF8AcwB0AGEAcgB0AAAAcwBlAAAAcwB0AGEAbgBkAGIAeQAAAA=="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "ヘビーリンペットランチャーEX"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Heavy Limpet Launcher EX"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "ヘビーリンペットランチャーEX"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon613",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 1\n     Damage: 6800\n     Blast Area: Radius 17.5m\n     Reload: 10sec\n     Fire Rate: 1/sec\n     Range: 450m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Heavy Limpet Launcher is a series of experimental Sniper Limpet Launchers which have completely sacrificed range and velocity in pursuit of loading the single largest Limpet possible.  The result is a devastating superweapon that places the power of the C line of explosives in the standard Limpet Launcher package.  However the weapon is entirely adapted around fitting only a single limpet.  On top of that it's so large and cumbersome to load that this variety of Limpet Launcher has by far the slowest reload time.  An acceptable downside for having the power of a small airstrike in a single gun.\n\nThis version is the EX model featuring a titanic improvement to performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon614_Limpet-Chain-Gun-M2.json
+++ b/examples/weapon/_Weapon614_Limpet-Chain-Gun-M2.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 6
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 1440
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 5.5
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.93
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 3
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 35
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombR_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1.189210057258606
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 325
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 312
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・チェーンガンＭ２"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Chain Gun M2"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・チェーンガンＭ２"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon614",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 6\n     Damage: 1440\n     Blast Area: Radius 5.5m\n     Reload: 5.2sec\n     Fire Rate: 1.71/sec\n     Range: 325m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThe Chaingun model is a heavily modified version: The loading mechanism was completely overhauled to accept small belt-fed magazines of Limpets, the result being a dramatic improvement in fire rate over the other Limpet Launchers.  However to achieve this smaller but higher grade limpets were used, resulting in lower velocity shots that cause smaller but equally intense explosions.  The new magazine is also tricky to install and has extended loading times significantly as a result.  Overall the weapon is capable of outputting much more damage than the average Limpet Gun, but loses some of its flexibility and is far more expensive to produce limiting it to special forces use only.\n\nThe Mark 2 version improves on this design, providing further enhanced performance."
+  }
+}

--- a/examples/weapon/_Weapon615_Limpet-Detector-ME.json
+++ b/examples/weapon/_Weapon615_Limpet-Detector-ME.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 74
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechetteAuto_L"
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.98
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+           "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 130
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.40
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.33
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 69
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.4000000059604645
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_searchME"
+        },
+        {
+          "type": "float",
+          "value": 0.5299999713897705
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 555
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 186
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リンペットスプレンダーＭE"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor ME"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リンペットスプレンダーＭE"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon615",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 74x30\n     Shrapnel: 2.16sec/140% Speed/33% Size\n     Reload: 3.1sec\n     Fire Rate: 0.87/sec\n     Range: 555m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the ME version featuring a titanic improvement to performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon616_Limpet-Gun-MA.json
+++ b/examples/weapon/_Weapon616_Limpet-Gun-MA.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 2460
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 8
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_M"
+        },
+        {
+          "type": "float",
+          "value": 0.8913000226020813
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 4
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.95
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾大着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 60
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombMA_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 500
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 189
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペットガンＭA"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Gun MA"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペットガンＭA"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon616",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 400\n     Blast Area: Radius 6.5m\n     Reload: 3.4sec\n     Fire Rate: 0.76/sec\n     Range: 480m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis is the MA version featuring a titanic improvement to performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon617_Limpet-Sniper-MA2.json
+++ b/examples/weapon/_Weapon617_Limpet-Sniper-MA2.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 4
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 2
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 3700
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 9
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 9
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 120
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombSnipeMA2_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 1140
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 324
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/mark_snp.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_sniper01.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_sniper01.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_sniper01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABwAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAcAIAAHwCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAAB2AgAAigIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAA4gIAAAAAAAC8AAAA7AAAAMICAAABAAAAzAAAAOwAAACqAgAAAQAAANwAAADsAAAAlAIAAAEAAADcAgAAAAAAQQAAAAAQAgAA3AIAAAAAAAAAAAAAYAEAANwCAAAAAJBBAAAAALABAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MFVci5UAAAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MM5TDX0AAAAAMAAxAAAASQBLAAAAYgBhAHIAcgBlAGwAAABiAG8AZAB5AAAAcgBlAGwAbwBhAGQAXwBlAG4AZAAAAHIAZQBsAG8AYQBkAF8AbABvAG8AcAAAAHIAZQBsAG8AYQBkAF8AcwB0AGEAcgB0AAAAcwBlAAAAcwB0AGEAbgBkAGIAeQAAAA=="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スナイプガンＭＡ２"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Sniper MA2"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スナイプガンＭＡ２"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon617",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 3700\n     Blast Area: Radius 9m\n     Reload: 5.4sec\n     Fire Rate: 0.5/sec\n     Range: 1140m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nAdapted from standard issue Ranger sniper platforms such as the 'Stringer' the Limpet Sniper series of Limpet Launchers has superior range and velocity. It even fires a larger caliber of Limpet allowing for devastating point strikes at extreme range.  However this drastically limits the amount of ammo the weapon can load in it's internal magazine.  That combined with the issues of loading the larger limpets means this series of Limpet launchers has poor ammo capacity and reload speed, hurting its flexibility at closer ranges.\n\nThis is the MA2 version featuring a titanic improvement to performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon618_Splendor-Chain-Gun.json
+++ b/examples/weapon/_Weapon618_Splendor-Chain-Gun.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 10
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 60
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_L"
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.95
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 2
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -1.5700000524520874
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 135
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.40
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.33
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 40
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombRChain_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 400
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 240
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "スプレンダー・チェーンガン"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Splendor Chain Gun"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "スプレンダー・チェーンガン"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon618",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 250x8\n     Shrapnel: 1.1sec/135% Speed/0.32% Size\n     Reload: 3.15sec\n     Fire Rate: 0.83/sec\n     Range: 545m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThe Chaingun variety is a heavily modified version: The loading mechanism was completely overhauled to accept small belt-fed magazines of Limpets, the result being a dramatic improvement in fire rate over the other Limpet Launchers.  However to achieve this smaller but higher grade limpets were used, resulting in lower velocity shots that cause smaller but equally intense explosions.  The new magazine is also tricky to install and has extended loading times significantly as a result.  Overall the weapon is capable of outputting much more damage than the average Limpet Gun, but loses some of its flexibility and is far more expensive to produce limiting it to special forces use only."
+  }
+}

--- a/examples/weapon/_Weapon619_Limpet-Gun-MT.json
+++ b/examples/weapon/_Weapon619_Limpet-Gun-MT.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 300
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 1660
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 7.5
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_M"
+        },
+        {
+          "type": "float",
+          "value": 0.8913000226020813
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.95
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0.11999999731779099
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 3
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 80
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombMT_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 180
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 240
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リンペットショットＭT"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Shot MT"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リンペットショットＭT"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon619",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 340x3\n     Blast Area: Radius 6.75m\n     Reload: 4.25sec\n     Fire Rate: 0.67/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis improved 'Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant.\n\nThis is the MT model featuring a titanic improvement to performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon620_Splendor-Shot-AX.json
+++ b/examples/weapon/_Weapon620_Splendor-Shot-AX.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 150
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 36
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_L"
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.99
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -0.5
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 140
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.45
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.34
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0.11
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 5
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 86
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_spreadBearing"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 200
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 213
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "スプレンダー・ショットＡＸ"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Splendor Shot AX"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "スプレンダー・ショットＡＸ"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon620",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 36x5x30\n     Shrapnel: 2.33sec/145% Speed/34% Size\n     Reload: 3.55sec\n     Fire Rate: 0.7/sec\n     Range: 200m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis 'Shot' version has been modified to fire 5 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 4 additional shots provide more damage and coverage than the standard Splendor variant.\n\nThis is the AX model featuring a titanic improvement to performance compared to the original model."
+  }
+}

--- a/examples/weapon/_Weapon621_Limpet-Heavy-Gun.json
+++ b/examples/weapon/_Weapon621_Limpet-Heavy-Gun.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 10000
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 20
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1.25
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_L"
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 0.8899999856948853
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 10
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.8
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾大着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 60
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombHeavy_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 600
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 600
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "ヘビーリンペットランチャーZD"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Heavy Limpet Launcher ZD"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "ヘビーリンペットランチャーZD"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon621",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 1\n     Damage: 10000\n     Blast Area: Radius 20m\n     Reload: 10sec\n     Fire Rate: 1/sec\n     Range: 600m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Heavy Limpet Launcher is a series of experimental Sniper Limpet Launchers which have completely sacrificed range and velocity in pursuit of loading the single largest Limpet possible.  The result is a devastating superweapon that places the power of the C line of explosives in the standard Limpet Launcher package.  However the weapon is entirely adapted around fitting only a single limpet.  On top of that it's so large and cumbersome to load that this variety of Limpet Launcher has by far the slowest reload time.  An acceptable downside for having the power of a small airstrike in a single gun.\n\nThis version is the ultimate ZD model that pushes the weapon's design to the absolute limit of current technology."
+  }
+}

--- a/examples/weapon/_Weapon622_Limpet-Splendor-ZD.json
+++ b/examples/weapon/_Weapon622_Limpet-Splendor-ZD.json
@@ -1,0 +1,709 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 5
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 95
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_explodeFrechette_L"
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker02.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 3
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0.5
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 1
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": [
+            {
+              "type": "ptr",
+              "name": "FlechetteSpread",
+              "value": [
+                {
+                  "type": "float",
+                  "name": "Horizontal",
+                  "value": 3.140000104904175
+                },
+                {
+                  "type": "float",
+                  "name": "Vertical",
+                  "value": -0.5
+                },
+                {
+                  "type": "float",
+                  "name": "VerticalOffset",
+                  "value": 1.5700000524520874
+                }
+              ]
+            },
+            {
+              "type": "float",
+              "name": "SearchRange",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "FlechetteCount",
+              "value": 30
+            },
+            {
+              "type": "int",
+              "name": "FlechetteAlive",
+              "value": 150
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSpeed",
+              "value": 1.50
+            },
+            {
+              "type": "float",
+              "name": "FlechetteSize",
+              "value": 0.35
+            },
+            {
+              "type": "ptr",
+              "value": [
+                {
+                  "type": "int",
+                  "value": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器フレシェット着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 63
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_frechetteShot_splenderZD"
+        },
+        {
+          "type": "float",
+          "value": 0.5299999713897705
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 575
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 180
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal02.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal02.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スプレンダーＺＤ"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Splendor ZD"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スプレンダーＺＤ"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker02.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon622",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 95x30\n     Shrapnel: 1.5sec/150% Speed/35% Size\n     Reload: 3sec\n     Fire Rate: 0.95/sec\n     Range: 575m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is the ultimate ZD model that pushes the weapon's design to the absolute limit of current technology."
+	}
+}

--- a/examples/weapon/_Weapon623_Limpet-Sniper-ZD.json
+++ b/examples/weapon/_Weapon623_Limpet-Sniper-ZD.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 4
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 2
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 4700
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 10
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 10
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 120
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombSnipeZD_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.5899999737739563
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 240
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/mark_snp.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_sniper01.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_sniper01.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_sniper01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABwAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAcAIAAHwCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAAB2AgAAigIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAA4gIAAAAAAAC8AAAA7AAAAMICAAABAAAAzAAAAOwAAACqAgAAAQAAANwAAADsAAAAlAIAAAEAAADcAgAAAAAAQQAAAAAQAgAA3AIAAAAAAAAAAAAAYAEAANwCAAAAAJBBAAAAALABAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MFVci5UAAAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAADwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwuTDKMKQw0TD8MM5TDX0AAAAAMAAxAAAASQBLAAAAYgBhAHIAcgBlAGwAAABiAG8AZAB5AAAAcgBlAGwAbwBhAGQAXwBlAG4AZAAAAHIAZQBsAG8AYQBkAF8AbABvAG8AcAAAAHIAZQBsAG8AYQBkAF8AcwB0AGEAcgB0AAAAcwBlAAAAcwB0AGEAbgBkAGIAeQAAAA=="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・スナイプガンＺＤ"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Sniper ZD"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・スナイプガンＺＤ"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon623",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 4700\n     Blast Area: Radius 10m\n     Reload: 5.25sec\n     Fire Rate: 0.5/sec\n     Range: 1200m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nAdapted from standard issue Ranger sniper platforms such as the 'Stringer' the Limpet Sniper series of Limpet Launchers has superior range and velocity. It even fires a larger caliber of Limpet allowing for devastating point strikes at extreme range.  However this drastically limits the amount of ammo the weapon can load in it's internal magazine.  That combined with the issues of loading the larger limpets means this series of Limpet launchers has poor ammo capacity and reload speed, hurting its flexibility at closer ranges.\n\nThis version is the ultimate ZD model that pushes the weapon's design to the absolute limit of current technology."
+  }
+}

--- a/examples/weapon/_Weapon624_Limpet-Chain-Gun-ZD.json
+++ b/examples/weapon/_Weapon624_Limpet-Chain-Gun-ZD.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 10
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 1500
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 6
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 4
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.9
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 2
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 30
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBombRZD_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.4699999988079071
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0.05000000074505806
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 350
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 300
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペット・チェーンガンＺＤ"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Chain Gun ZD"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペット・チェーンガンＺＤ"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "Weapon624",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 10\n     Damage: 1500\n     Blast Area: Radius 6m\n     Reload: 5sec\n     Fire Rate: 2/sec\n     Range: 350m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThe Chaingun model is a heavily modified version: The loading mechanism was completely overhauled to accept small belt-fed magazines of Limpets, the result being a dramatic improvement in fire rate over the other Limpet Launchers.  However to achieve this smaller but higher grade limpets were used, resulting in lower velocity shots that cause smaller but equally intense explosions.  The new magazine is also tricky to install and has extended loading times significantly as a result.  Overall the weapon is capable of outputting much more damage than the average Limpet Gun, but loses some of its flexibility and is far more expensive to produce limiting it to special forces use only.\n\nThis version is the ultimate ZD model that pushes the weapon's design to the absolute limit of current technology."
+  }
+}

--- a/examples/weapon/_eLimpetGun01_Limpet-Gun.json
+++ b/examples/weapon/_eLimpetGun01_Limpet-Gun.json
@@ -1,0 +1,653 @@
+{
+  "endian": "BE",
+  "variables": [
+    {
+      "type": "string",
+      "name": "AimAnimation",
+      "value": "aim"
+    },
+    {
+      "type": "int",
+      "name": "AmmoAlive",
+      "value": 1200
+    },
+    {
+      "type": "string",
+      "name": "AmmoClass",
+      "options": [
+        "LightningBullet01",
+        "LaserBullet01",
+        "LaserBullet02",
+        "LaserBullet03",
+        "FlameBullet01",
+        "FlameBullet02",
+        "SpiderStringBullet01",
+        "SpiderStringBullet02",
+        "ShockWaveBullet01",
+        "SlashWaveBullet01",
+        "HomingLaserBullet01",
+        "BeamBullet01",
+        "DecoyBullet01",
+        "NeedleBullet01",
+        "BarrierBullet01",
+        "ClusterBullet01",
+        "AcidBullet01",
+        "NapalmBullet01",
+        "GrenadeBullet01",
+        "MissileBullet01",
+        "MissileBullet02",
+        "RocketBullet01",
+        "RocketBullet02",
+        "SolidBullet01",
+        "SolidBullet02",
+        "SmokeCandleBullet01",
+        "ShieldBashBullet01",
+        "SentryGunBullet01",
+        "TargetMarkerBullet01",
+        "SupportUnitBullet01",
+        "PileBunkerBullet01",
+        "PlasmaBullet01"
+      ],
+      "value": "BombBullet01"
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoColor",
+      "value": [
+        {
+          "type": "float",
+          "name": "Red",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "name": "Green",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Blue",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "name": "Alpha",
+          "value": 0.5
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "AmmoCount",
+      "value": 3
+    },
+    {
+      "type": "float",
+      "name": "AmmoDamage",
+      "value": 130
+    },
+    {
+      "type": "float",
+      "name": "AmmoExplosion",
+      "value": 6
+    },
+    {
+      "type": "float",
+      "name": "AmmoGravityFactor",
+      "value": 1
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitImpulseAdjust",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "AmmoHitSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "value": "common_damages_rimpetExp_S"
+        },
+        {
+          "type": "float",
+          "value": 0.7943000197410583
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 200
+        }
+      ]
+    },
+    {
+      "type": "float",
+      "name": "AmmoHitSizeAdjust",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "AmmoIsPenetration",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "AmmoModel",
+      "value": "app:/WEAPON/bullet_marker.rab"
+    },
+    {
+      "type": "float",
+      "name": "AmmoOwnerMove",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "AmmoSize",
+      "value": 2
+    },
+    {
+      "type": "float",
+      "name": "AmmoSpeed",
+      "value": 0.85
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_CustomParameter",
+      "value": [
+        {
+          "type": "int",
+          "name": "BombMobility",
+          "options": {
+            "None": 0,
+            "Roll": 1,
+            "Bounce": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "IsDetector",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "name": "PrimerDelay",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 5
+        },
+        {
+          "type": "ptr",
+          "name": "LedPosition",
+          "value": [
+            {
+              "type": "float",
+              "name": "Red",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Green",
+              "value": 0
+            },
+            {
+              "type": "float",
+              "name": "Blue",
+              "value": 0.10000000149011612
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "name": "BombExplosionType",
+          "options": {
+            "Explosion": 0,
+            "Shrapnel": 1,
+            "Burst": 2
+          },
+          "value": 0
+        },
+        {
+          "type": "ptr",
+          "name": "SplendorParameter",
+          "value": null
+        },
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "武器リモート爆弾小着弾"
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "Ammo_EquipVoice",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "AngleAdjust",
+      "value": 0
+    },
+    {
+      "type": "string",
+      "name": "BaseAnimation",
+      "value": "assault"
+    },
+    {
+      "type": "string",
+      "name": "ChangeAnimation",
+      "value": "assault_change1"
+    },
+    {
+      "type": "float",
+      "name": "EnergyChargeRequire",
+      "value": -1
+    },
+    {
+      "type": "float",
+      "name": "FireAccuracy",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireBurstCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireBurstInterval",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCondition",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireCount",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "FireInterval",
+      "value": 85
+    },
+    {
+      "type": "ptr",
+      "name": "FireLoadSe",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "FireRecoil",
+      "value": 0.20000000298023224
+    },
+    {
+      "type": "ptr",
+      "name": "FireSe",
+      "value": [
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "string",
+          "name": "SoundName",
+          "value": "weapon_Engineer_BOM_remoteBomb_shot"
+        },
+        {
+          "type": "float",
+          "value": 0.6309999823570251
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 1
+        },
+        {
+          "type": "float",
+          "value": 25
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "FireSpreadType",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "FireSpreadWidth",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "FireType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "FireVector",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "LockonAngle",
+      "value": [
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        },
+        {
+          "type": "float",
+          "value": 0.30000001192092896
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "LockonFailedTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonHoldTime",
+      "value": 0
+    },
+    {
+      "type": "float",
+      "name": "LockonRange",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTargetType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonTime",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "LockonType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_AutoTimeOut",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "Lockon_DistributionType",
+      "value": 0
+    },
+    {
+      "type": "int",
+      "name": "Lockon_FireEndToClear",
+      "value": 1
+    },
+    {
+      "type": "ptr",
+      "name": "ModelConstraint",
+      "value": [
+        {
+          "type": "string",
+          "value": "arms_r"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "MuzzleFlash",
+      "value": ""
+    },
+    {
+      "type": "ptr",
+      "name": "MuzzleFlash_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "float",
+      "name": "Range",
+      "value": 450
+    },
+    {
+      "type": "string",
+      "name": "ReloadAnimation",
+      "value": "assault_reload1"
+    },
+    {
+      "type": "float",
+      "name": "ReloadInit",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "name": "ReloadTime",
+      "value": 210
+    },
+    {
+      "type": "int",
+      "name": "ReloadType",
+      "value": 0
+    },
+    {
+      "type": "ptr",
+      "name": "SecondaryFire_Parameter",
+      "value": null
+    },
+    {
+      "type": "int",
+      "name": "SecondaryFire_Type",
+      "options": {
+        "None": 0,
+        "Zoom": 1,
+        "Activate": 2,
+        "Activate and Reload": 3,
+        "Jumpjets (Fencer)": 4,
+        "Dash (Fencer)": 5,
+        "Shield Reflect (Fencer)": 6
+      },
+      "value": 2
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase",
+      "value": [
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "string",
+          "value": ""
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCaseDischargeSe",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "ShellCase_CustomParameter",
+      "value": null
+    },
+    {
+      "type": "ptr",
+      "name": "Sight_animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/HUD/sight13.rab"
+            },
+            {
+              "type": "string",
+              "value": "sight13.mdb"
+            }
+          ]
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "name": "WeaponIcon",
+      "value": "app:/weapon/icon/m_launcher.dds"
+    },
+    {
+      "type": "ptr",
+      "name": "animation_model",
+      "value": [
+        {
+          "type": "ptr",
+          "value": [
+            {
+              "type": "string",
+              "value": "app:/Weapon/e_markerlauncher_normal03.rab"
+            },
+            {
+              "type": "string",
+              "value": "e_markerlauncher_normal03.mdb"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "value": "app:/Weapon/e_markerlauncher_normal01.cas"
+        },
+        {
+          "type": "extra",
+          "value": {
+            "type": "MAB\u0000",
+            "data": "TUFCAA8AAAADAAAAAwAEAAUAggAkAAAAfAAAAPAAAABcAgAAAAABADwAAAABAAEAXAAAAAIAAAB8AAAAXAIAAGgCAAACAAAAMAEAAAABAADwAAAAAAAAAEABAABiAgAAdgIAAAIAAAAQAQAAAAEAACABAAAAAAAAQAEAALwAAADsAAAAzgIAAAAAAAC8AAAA7AAAAK4CAAABAAAAzAAAAOwAAACWAgAAAQAAANwAAADsAAAAgAIAAAEAAADIAgAAAAAAQQAAAACwAQAAyAIAAAAAAAAAAAAAYAEAAMgCAAAAAJBBAAAAAAQCAAC6urq6AAAAAAAAAAAAAAAAAACAP83MzD3NzMw9zczMPQAAgD+PwvU9zczMvOXQIj4AAIA/+2qyPna7ab5DTkhAAACAPwAAAIApXI+9KVyPPgAAgD9TR08AAgEAAAAAAAAgAAAAAAAAACAAAAAAAAAAIAAAAFNHTwACAQAAAQAAACAAAAABAAAALAAAAAAAAAA0AAAAAwAAAAgAAAAeAAAACAAAAAAAAABuAGEAbQBlAAAAJf8u/+ow7TD8MMkwn1s+XwAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACgAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwLn6AMAAAU0dPAAIBAAABAAAAIAAAAAEAAAAsAAAAAAAAADQAAAADAAAACwAAAB4AAAAIAAAAAAAAAG4AYQBtAGUAAADeMPwwqzD8MOkw8zDBMOMwOE9zMIswAAAAADAAMQAAAEkASwAAAGIAYQByAHIAZQBsAAAAYgBvAGQAeQAAAHIAZQBsAG8AYQBkAF8AZQBuAGQAAAByAGUAbABvAGEAZABfAGwAbwBvAHAAAAByAGUAbABvAGEAZABfAHMAdABhAHIAdAAAAHMAZQAAAHMAdABhAG4AZABiAHkAAAA="
+          }
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "custom_parameter",
+      "value": [
+        {
+          "type": "string",
+          "value": "assault_recoil1"
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "int",
+          "value": 0
+        },
+        {
+          "type": "float",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "name",
+      "value": [
+        {
+          "type": "string",
+          "name": "Japanese",
+          "value": "リムペットガン"
+        },
+        {
+          "type": "string",
+          "name": "English",
+          "value": "Limpet Gun"
+        },
+        {
+          "type": "string",
+          "name": "Chinese",
+          "value": "リムペットガン"
+        }
+      ]
+    },
+    {
+      "type": "ptr",
+      "name": "resource",
+      "value": [
+        {
+          "type": "string",
+          "name": "path",
+          "value": "app:/WEAPON/bullet_marker.rab"
+        }
+      ]
+    },
+    {
+      "type": "int",
+      "name": "use_underground",
+      "value": 1
+    },
+    {
+      "type": "string",
+      "name": "xgs_scene_object_class",
+      "value": "Weapon_BasicShoot"
+    }
+  ],
+  "meta": {
+    "id": "eLimpetGun01",
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 130.0\n     Blast Area: Radius 6.0m\n     Reload: 3.5sec\n     Fire Rate: 0.71/sec\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis version is a direct-to-manufacture model based on the original prototype.  While unrefined compared to later models, it is cheap to build enmass and has a proven record against the Giant Insects 8 years ago."
+  }
+}

--- a/rebalance/rebalance.js
+++ b/rebalance/rebalance.js
@@ -583,12 +583,76 @@ rebalance({category: 36, name: /Titan/}, (template, i, meta, text) => {
     const vehicleParameters = summonParameters.value[3]
     const strengthParameters = vehicleParameters.value[0]
     const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 2.5
+    healthFactor.value *= 3.170289855
     return values
   })
   replaceText(text,
     /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 2.5}`
+    (match, hp) => `Durability: ${hp * 3.170289855}`
+  )
+})
+
+rebalance({category: 36, name:/Gigantus/}, (template, i, meta, text) => {
+  // Increase durability of all normal tanks
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 3.2
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 3.2}`
+  )
+})
+
+rebalance({category: 36, name:/Armored Railgun/}, (template, i, meta, text) => {
+  // Increase durability of all Armored Railguns
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 3
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 3}`
+  )
+})
+
+rebalance({category: 37}, (template, i, meta, text) => {
+  // Increase durability of all ground vehicles
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 5.132275132
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 5.132275132}`
+  )
+})
+
+rebalance({category: 37, name: /SDL1/}, (template, i, meta, text) => {
+  // Returns the bikes to being squishy
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 0.2
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 0.2}`
   )
 })
 
@@ -631,20 +695,55 @@ rebalance({category: 37, name: /Grape/}, (template, i, meta, text) => {
   })
 })
 
-rebalance({category: 39}, (template, i, meta, text) => {
-  // Increase durability of all power suits
+rebalance({category: 38}, (template, i, meta, text) => {
+  // Increase durability of all Helicopters
   patch(template, 'Ammo_CustomParameter', values => {
     const summonParameters = values[4]
     const vehicleParameters = summonParameters.value[3]
     const strengthParameters = vehicleParameters.value[0]
     const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 2
+    healthFactor.value *= 4.166666667
     return values
   })
   replaceText(text,
     /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 2}`
+    (match, hp) => `Durability: ${hp * 4.166666667}`
   )
+})
+
+rebalance({category: 39, name:/BEGARUTA/}, (template, i, meta, text) => {
+  // Increase durability of all medium power suits
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 3.571428571
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 3.571428571}`
+  )
+})
+
+rebalance({category: 39, /Depth-Crawler/}, (template, i, meta, text) => {
+  // Increase durability of all depth crawlers
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 5.333333333
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 5.333333333}`
+  )
+})
+
+
 })
 
 function json(obj) {


### PR DESCRIPTION
Details of the overhauls can be seen on this spreadsheet:

[Limpets](https://docs.google.com/spreadsheets/d/1ZcMneUf43jbCpKrSBvFZIcAq3WYP4qrdeNGkuvbcuco/edit#gid=0&range=B2)

[Durability](https://docs.google.com/spreadsheets/d/1ZcMneUf43jbCpKrSBvFZIcAq3WYP4qrdeNGkuvbcuco/edit#gid=1898067740&range=A20)

In general Limpets were made much slower (much lower fire rate, longer reload times, lower projectile velocity) and in exchange much more powerful per shot (Higher per hit damage, higher AoE/Faster and longer lived shrapnel)

Vehicles (excluding Bikes) have had their armour increased between 3-5x depending on the model, the goal being to prevent near instant destruction on inferno mode vs ants.  Testing on the effect this has vs other enemy types is required however