### PR TITLE
Further rebalancing

### DIFF
--- a/examples/weapon/_Weapon595_Limpet-Splendor.json
+++ b/examples/weapon/_Weapon595_Limpet-Splendor.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 6
+      "value": 4
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.9
+      "value": 1.45
     },
     {
       "type": "ptr",
@@ -257,12 +257,12 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 90
+              "value": 20
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon595",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 6x30\n     Shrapnel: 1.50sec/100% Speed/25% Size\n     Reload: 3.5sec\n     Fire Rate: 0.65/sec\n     Range: 475m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is a direct-to-manufacture model based on the original prototype.  While unrefined compared to later models, it is cheap to build enmass and has a proven record against the Giant Insects 8 years ago."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 4x20\n     Shrapnel: 0.33sec/100% Speed/25% Size\n     Reload: 3.5sec\n     Fire Rate: 0.65/sec\n     Range: 475m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is a direct-to-manufacture model based on the original prototype.  While unrefined compared to later models, it is cheap to build enmass and has a proven record against the Giant Insects 8 years ago."
   }
 }

--- a/examples/weapon/_Weapon596_Limpet-Sniper.json
+++ b/examples/weapon/_Weapon596_Limpet-Sniper.json
@@ -94,7 +94,7 @@
     {
       "type": "float",
       "name": "AmmoGravityFactor",
-      "value": 0
+      "value": 1
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 5
+      "value": 6
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon597_Limpet-Gun-D.json
+++ b/examples/weapon/_Weapon597_Limpet-Gun-D.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.86
+      "value": 1.55
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon598_Limpet-Splendor-D.json
+++ b/examples/weapon/_Weapon598_Limpet-Splendor-D.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 12
+      "value": 10
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.91
+      "value": 1.50
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 95
+              "value": 21
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.05
+              "value": 1.03
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon598",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 12x30\n     Shrapnel: 1.58sec/105% Speed/0.26% Size\n     Reload: 3.45sec\n     Fire Rate: 0.67/sec\n     Range: 485m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is an enhanced model compared to the original design featuring overall better performance."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 10x30\n     Shrapnel: 0.35sec/103% Speed/0.26% Size\n     Reload: 3.45sec\n     Fire Rate: 0.67/sec\n     Range: 485m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is an enhanced model compared to the original design featuring overall better performance."
   }
 }

--- a/examples/weapon/_Weapon599_Limpet-Gun-M2.json
+++ b/examples/weapon/_Weapon599_Limpet-Gun-M2.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.87
+      "value": 1.60
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon600_Limpet-Sniper-D.json
+++ b/examples/weapon/_Weapon600_Limpet-Sniper-D.json
@@ -94,7 +94,7 @@
     {
       "type": "float",
       "name": "AmmoGravityFactor",
-      "value": 0
+      "value": 1
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 6
+      "value": 6.25
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon601_Limpet-Splendor-M2.json
+++ b/examples/weapon/_Weapon601_Limpet-Splendor-M2.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 26
+      "value": 22
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.92
+      "value": 1.55
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 100
+              "value": 22
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.10
+              "value": 1.05
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon601",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 26x30\n     Shrapnel: 1.66sec/110% Speed/27% Size\n     Reload: 3.40sec\n     Fire Rate: 0.69/sec\n     Range: 495m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 2 version featuring greatly improved performance compared to the original model."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 22x20\n     Shrapnel: 0.37sec/105% Speed/27% Size\n     Reload: 3.40sec\n     Fire Rate: 0.69/sec\n     Range: 495m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 2 version featuring greatly improved performance compared to the original model."
   }
 }

--- a/examples/weapon/_Weapon602_Limpet-Launcher.json
+++ b/examples/weapon/_Weapon602_Limpet-Launcher.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.5
+      "value": 0.85
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon603_Limpet-Splendor-A30.json
+++ b/examples/weapon/_Weapon603_Limpet-Splendor-A30.json
@@ -79,12 +79,12 @@
     {
       "type": "int",
       "name": "AmmoCount",
-      "value": 30
+      "value": 10
     },
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 24
+      "value": 28
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.93
+      "value": 1.60
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 105
+              "value": 23
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.15
+              "value": 1.08
             },
             {
               "type": "float",
@@ -666,17 +666,17 @@
         {
           "type": "string",
           "name": "Japanese",
-          "value": "リムペット・スプレンダーＡ３０"
+          "value": "リムペット・スプレンダーＡ10"
         },
         {
           "type": "string",
           "name": "English",
-          "value": "Limpet Splendor A30"
+          "value": "Limpet Splendor A10"
         },
         {
           "type": "string",
           "name": "Chinese",
-          "value": "リムペット・スプレンダーＡ３０"
+          "value": "リムペット・スプレンダーＡ10"
         }
       ]
     },
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon603",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 30\n     Damage: 24x30\n     Shrapnel: 1.75sec/115% Speed/28% Size\n     Reload: 6.5sec\n     Fire Rate: 0.71/sec\n     Range: 505m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is a modified Splendor M2 made compatible with an extremely large extended magazine resulting in a colossal 30 Limpet capacity.  However the new magazine is unwieldy to work with and nearly doubles the time needed to reload.  An excellent weapon for setting elaborate traps, the full 30 detonations making quite the fireworks show."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 10\n     Damage: 18x30\n     Shrapnel: 0.58sec/115% Speed/28% Size\n     Reload: 6.5sec\n     Fire Rate: 0.71/sec\n     Range: 505m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is a modified Splendor M2 made compatible with an extremely large extended magazine resulting in a colossal 10 Limpet capacity.  However the new magazine is unwieldy to work with and nearly doubles the time needed to reload.  An excellent weapon for setting elaborate traps, the full 10 detonations making quite the fireworks show."
   }
 }

--- a/examples/weapon/_Weapon604_Limpet-Gun-M3.json
+++ b/examples/weapon/_Weapon604_Limpet-Gun-M3.json
@@ -89,7 +89,7 @@
     {
       "type": "float",
       "name": "AmmoExplosion",
-      "value": 6.25
+      "value": 4.75
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.88
+      "value": 1.65
     },
     {
       "type": "ptr",
@@ -648,6 +648,6 @@
   ],
   "meta": {
     "id": "Weapon604",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 140x3\n     Blast Area: Radius 6.25m\n     Reload: 4.35sec\n     Fire Rate: 0.63/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 140x3\n     Blast Area: Radius 4.75m\n     Reload: 4.35sec\n     Fire Rate: 0.63/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant."
   }
 }

--- a/examples/weapon/_Weapon605_Splendor-Shot.json
+++ b/examples/weapon/_Weapon605_Splendor-Shot.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 14
+      "value": 22
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.94
+      "value": 1.65
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 110
+              "value": 24
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.20
+              "value": 0.85
             },
             {
               "type": "float",
@@ -356,7 +356,7 @@
     {
       "type": "int",
       "name": "FireCount",
-      "value": 5
+      "value": 3
     },
     {
       "type": "int",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon605",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 14x5x30\n     Shrapnel: 1.83sec/120% Speed/29% Size\n     Reload: 3.8sec\n     Fire Rate: 0.6/sec\n     Range: 160m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis 'Shot' version however has been modified to fire 5 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 4 additional shots provide more damage and coverage than the standard Splendor variant."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 10x5x30\n     Shrapnel: 0.6sec/85% Speed/29% Size\n     Reload: 3.8sec\n     Fire Rate: 0.6/sec\n     Range: 160m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis 'Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Splendor variant."
   }
 }

--- a/examples/weapon/_Weapon606_Limpet-Splendor-M3.json
+++ b/examples/weapon/_Weapon606_Limpet-Splendor-M3.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 40
+      "value": 34
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.95
+      "value": 1.70
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 115
+              "value": 25
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.25
+              "value": 1.13
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon606",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 40x30x8\n     Shrapnel: 1.91sec/125% Speed/30% Size\n     Reload: 3.25sec\n     Fire Rate: 0.77/sec\n     Range: 525m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 3 version featuring hugely improved performance compared to the original model."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 34x20\n     Shrapnel: 0.42sec/113% Speed/30% Size\n     Reload: 3.25sec\n     Fire Rate: 0.77/sec\n     Range: 525m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 3 version featuring hugely improved performance compared to the original model."
   }
 }

--- a/examples/weapon/_Weapon607_Limpet-Chain-Gun.json
+++ b/examples/weapon/_Weapon607_Limpet-Chain-Gun.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.84
+      "value": 1.20
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon608_Limpet-Sniper-A3.json
+++ b/examples/weapon/_Weapon608_Limpet-Sniper-A3.json
@@ -94,7 +94,7 @@
     {
       "type": "float",
       "name": "AmmoGravityFactor",
-      "value": 0
+      "value": 1
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 7
+      "value": 6.5
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon609_Limpet-Detector.json
+++ b/examples/weapon/_Weapon609_Limpet-Detector.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 52
+      "value": 44
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.96
+      "value": 1.75
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 120
+              "value": 26
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.30
+              "value": 1.15
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon609",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 52x30\n     Shrapnel: 2sec/130% Speed/31% Size\n     Reload: 3.2sec\n     Fire Rate: 0.8/sec\n     Range: 525m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 4 version featuring colossally improved performance compared to the original model."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 44x20\n     Shrapnel: 0.43sec/115% Speed/31% Size\n     Reload: 3.2sec\n     Fire Rate: 0.8/sec\n     Range: 525m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the Mark 4 version featuring colossally improved performance compared to the original model."
   }
 }

--- a/examples/weapon/_Weapon610_Limpet-Shot.json
+++ b/examples/weapon/_Weapon610_Limpet-Shot.json
@@ -89,7 +89,7 @@
     {
       "type": "float",
       "name": "AmmoExplosion",
-      "value": 6.75
+      "value": 5.25
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.9
+      "value": 1.75
     },
     {
       "type": "ptr",
@@ -648,6 +648,6 @@
   ],
   "meta": {
     "id": "Weapon610",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 340x3\n     Blast Area: Radius 6.75m\n     Reload: 4.25sec\n     Fire Rate: 0.67/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis improved 'Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 340x3\n     Blast Area: Radius 5.25m\n     Reload: 4.25sec\n     Fire Rate: 0.67/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis improved 'Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant."
   }
 }

--- a/examples/weapon/_Weapon611_Limpet-Buster.json
+++ b/examples/weapon/_Weapon611_Limpet-Buster.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.9
+      "value": 1.8
     },
     {
       "type": "ptr",
@@ -450,7 +450,7 @@
     {
       "type": "float",
       "name": "Range",
-      "value": 459
+      "value": 540
     },
     {
       "type": "string",
@@ -648,6 +648,6 @@
   ],
   "meta": {
     "id": "Weapon611",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 1600\n     Blast Area: Radius 7m\n     Reload: 3.3sec\n     Fire Rate: 0.86/sec\n     Range: 450m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis is the Mark 3 version featuring hugely improved performance compared to the original model."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 1600\n     Blast Area: Radius 7m\n     Reload: 3.3sec\n     Fire Rate: 0.86/sec\n     Range: 540m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis is the Mark 3 version featuring hugely improved performance compared to the original model."
   }
 }

--- a/examples/weapon/_Weapon612_Limpet-Splendor-M9.json
+++ b/examples/weapon/_Weapon612_Limpet-Splendor-M9.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 66
+      "value": 58
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.97
+      "value": 1.8
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 125
+              "value": 27
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.35
+              "value": 1.18
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon612",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 66x30\n     Shrapnel: 2.08sec/135% Speed/0.32% Size\n     Reload: 3.15sec\n     Fire Rate: 0.83/sec\n     Range: 545m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThe Mark 9 had a troubled history: between it and the Mark 4 many prototypes failed to produce the results needed, almost resulting in the project being scrapped.  A breakthrough in Ravager based alloy technology finally meant the Mark 9 could produce shrapnel sharper than ever before from an explosive device while also making improvements to the launcher's performance in every other area."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 58x20\n     Shrapnel: 0.45sec/135% Speed/0.32% Size\n     Reload: 3.15sec\n     Fire Rate: 0.83/sec\n     Range: 545m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThe Mark 9 had a troubled history: between it and the Mark 4 many prototypes failed to produce the results needed, almost resulting in the project being scrapped.  A breakthrough in Ravager based alloy technology finally meant the Mark 9 could produce shrapnel sharper than ever before from an explosive device while also making improvements to the launcher's performance in every other area."
   }
 }

--- a/examples/weapon/_Weapon613_Limpet-Sniper-F3.json
+++ b/examples/weapon/_Weapon613_Limpet-Sniper-F3.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.65
+      "value": 0.925
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon614_Limpet-Chain-Gun-M2.json
+++ b/examples/weapon/_Weapon614_Limpet-Chain-Gun-M2.json
@@ -89,7 +89,7 @@
     {
       "type": "float",
       "name": "AmmoExplosion",
-      "value": 5.5
+      "value": 5.75
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.93
+      "value": 1.35
     },
     {
       "type": "ptr",
@@ -648,6 +648,6 @@
   ],
   "meta": {
     "id": "Weapon614",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 6\n     Damage: 1440\n     Blast Area: Radius 5.5m\n     Reload: 5.2sec\n     Fire Rate: 1.71/sec\n     Range: 325m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThe Chaingun model is a heavily modified version: The loading mechanism was completely overhauled to accept small belt-fed magazines of Limpets, the result being a dramatic improvement in fire rate over the other Limpet Launchers.  However to achieve this smaller but higher grade limpets were used, resulting in lower velocity shots that cause smaller but equally intense explosions.  The new magazine is also tricky to install and has extended loading times significantly as a result.  Overall the weapon is capable of outputting much more damage than the average Limpet Gun, but loses some of its flexibility and is far more expensive to produce limiting it to special forces use only.\n\nThe Mark 2 version improves on this design, providing further enhanced performance."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 6\n     Damage: 1440\n     Blast Area: Radius 5.75m\n     Reload: 5.2sec\n     Fire Rate: 1.71/sec\n     Range: 325m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThe Chaingun model is a heavily modified version: The loading mechanism was completely overhauled to accept small belt-fed magazines of Limpets, the result being a dramatic improvement in fire rate over the other Limpet Launchers.  However to achieve this smaller but higher grade limpets were used, resulting in lower velocity shots that cause smaller but equally intense explosions.  The new magazine is also tricky to install and has extended loading times significantly as a result.  Overall the weapon is capable of outputting much more damage than the average Limpet Gun, but loses some of its flexibility and is far more expensive to produce limiting it to special forces use only.\n\nThe Mark 2 version improves on this design, providing further enhanced performance."
   }
 }

--- a/examples/weapon/_Weapon615_Limpet-Detector-ME.json
+++ b/examples/weapon/_Weapon615_Limpet-Detector-ME.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 74
+      "value": 64
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.98
+      "value": 1.85
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 130
+              "value": 28
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.40
+              "value": 1.20
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon615",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 74x30\n     Shrapnel: 2.16sec/140% Speed/33% Size\n     Reload: 3.1sec\n     Fire Rate: 0.87/sec\n     Range: 555m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the ME version featuring a titanic improvement to performance compared to the original model."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 64x20\n     Shrapnel: 0.47sec/120% Speed/33% Size\n     Reload: 3.1sec\n     Fire Rate: 0.87/sec\n     Range: 555m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis is the ME version featuring a titanic improvement to performance compared to the original model."
   }
 }

--- a/examples/weapon/_Weapon616_Limpet-Gun-MA.json
+++ b/examples/weapon/_Weapon616_Limpet-Gun-MA.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.95
+      "value": 2.00
     },
     {
       "type": "ptr",
@@ -450,7 +450,7 @@
     {
       "type": "float",
       "name": "Range",
-      "value": 500
+      "value": 600
     },
     {
       "type": "string",
@@ -648,6 +648,6 @@
   ],
   "meta": {
     "id": "Weapon616",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 400\n     Blast Area: Radius 6.5m\n     Reload: 3.4sec\n     Fire Rate: 0.76/sec\n     Range: 480m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis is the MA version featuring a titanic improvement to performance compared to the original model."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 2460\n     Blast Area: Radius 8m\n     Reload: 3.15sec\n     Fire Rate: 1/sec\n     Range: 600m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis version is the ultimate MA model that pushes the weapon's design to the absolute limit of current technology."
   }
 }

--- a/examples/weapon/_Weapon617_Limpet-Sniper-MA2.json
+++ b/examples/weapon/_Weapon617_Limpet-Sniper-MA2.json
@@ -94,7 +94,7 @@
     {
       "type": "float",
       "name": "AmmoGravityFactor",
-      "value": 0
+      "value": 1
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 9
+      "value": 6.75
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon618_Splendor-Chain-Gun.json
+++ b/examples/weapon/_Weapon618_Splendor-Chain-Gun.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 60
+      "value": 52
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.95
+      "value": 1.40
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 135
+              "value": 29
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.40
+              "value": 1.00
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon618",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 250x8\n     Shrapnel: 1.1sec/135% Speed/0.32% Size\n     Reload: 3.15sec\n     Fire Rate: 0.83/sec\n     Range: 545m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThe Chaingun variety is a heavily modified version: The loading mechanism was completely overhauled to accept small belt-fed magazines of Limpets, the result being a dramatic improvement in fire rate over the other Limpet Launchers.  However to achieve this smaller but higher grade limpets were used, resulting in lower velocity shots that cause smaller but equally intense explosions.  The new magazine is also tricky to install and has extended loading times significantly as a result.  Overall the weapon is capable of outputting much more damage than the average Limpet Gun, but loses some of its flexibility and is far more expensive to produce limiting it to special forces use only."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 10\n     Damage: 52x20\n     Shrapnel: 0.48sec/100% Speed/0.32% Size\n     Reload: 3.15sec\n     Fire Rate: 0.83/sec\n     Range: 545m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThe Chaingun variety is a heavily modified version: The loading mechanism was completely overhauled to accept small belt-fed magazines of Limpets, the result being a dramatic improvement in fire rate over the other Limpet Launchers.  However to achieve this smaller but higher grade limpets were used, resulting in lower velocity shots that cause smaller but equally intense explosions.  The new magazine is also tricky to install and has extended loading times significantly as a result.  Overall the weapon is capable of outputting much more damage than the average Limpet Gun, but loses some of its flexibility and is far more expensive to produce limiting it to special forces use only.\n\nThis is the only Splendor Chaingun model ever made, and no expense was spared in its creation making this also the ultimate version"
   }
 }

--- a/examples/weapon/_Weapon619_Limpet-Gun-MT.json
+++ b/examples/weapon/_Weapon619_Limpet-Gun-MT.json
@@ -89,7 +89,7 @@
     {
       "type": "float",
       "name": "AmmoExplosion",
-      "value": 7.5
+      "value": 6
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.95
+      "value": 1.95
     },
     {
       "type": "ptr",
@@ -648,6 +648,6 @@
   ],
   "meta": {
     "id": "Weapon619",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 340x3\n     Blast Area: Radius 6.75m\n     Reload: 4.25sec\n     Fire Rate: 0.67/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis improved 'Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant.\n\nThis is the MT model featuring a titanic improvement to performance compared to the original model."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 2\n     Damage: 340x3\n     Blast Area: Radius 6m\n     Reload: 4.25sec\n     Fire Rate: 0.67/sec\n     Range: 150m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis improved 'Shot' version however has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Gun variant.\n\nThis is the MT model featuring a titanic improvement to performance compared to the original model."
   }
 }

--- a/examples/weapon/_Weapon620_Splendor-Shot-AX.json
+++ b/examples/weapon/_Weapon620_Splendor-Shot-AX.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 36
+      "value": 52
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.99
+      "value": 1.95
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 140
+              "value": 30
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.45
+              "value": 1.00
             },
             {
               "type": "float",
@@ -356,7 +356,7 @@
     {
       "type": "int",
       "name": "FireCount",
-      "value": 5
+      "value": 3
     },
     {
       "type": "int",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon620",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 36x5x30\n     Shrapnel: 2.33sec/145% Speed/34% Size\n     Reload: 3.55sec\n     Fire Rate: 0.7/sec\n     Range: 200m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis 'Shot' version has been modified to fire 5 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 4 additional shots provide more damage and coverage than the standard Splendor variant.\n\nThis is the AX model featuring a titanic improvement to performance compared to the original model."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 52x3x20\n     Shrapnel: 0.50sec/100% Speed/34% Size\n     Reload: 3.55sec\n     Fire Rate: 0.7/sec\n     Range: 200m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis 'Shot' version has been modified to fire 3 limpets at once from separate chambers much like a shotgun.  Like a shotgun however it has poor range, but the 2 additional shots provide more damage and coverage than the standard Splendor variant.\n\nThis version is the ultimate AX model that pushes the weapon's design to the absolute limit of current technology."
   }
 }

--- a/examples/weapon/_Weapon621_Limpet-Heavy-Gun.json
+++ b/examples/weapon/_Weapon621_Limpet-Heavy-Gun.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.8
+      "value": 1
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon622_Limpet-Splendor-ZD.json
+++ b/examples/weapon/_Weapon622_Limpet-Splendor-ZD.json
@@ -84,7 +84,7 @@
     {
       "type": "float",
       "name": "AmmoDamage",
-      "value": 95
+      "value": 80
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 1
+      "value": 2
     },
     {
       "type": "ptr",
@@ -257,17 +257,17 @@
             {
               "type": "int",
               "name": "FlechetteCount",
-              "value": 30
+              "value": 20
             },
             {
               "type": "int",
               "name": "FlechetteAlive",
-              "value": 150
+              "value": 33
             },
             {
               "type": "float",
               "name": "FlechetteSpeed",
-              "value": 1.50
+              "value": 1.25
             },
             {
               "type": "float",
@@ -704,6 +704,6 @@
   ],
   "meta": {
     "id": "Weapon622",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 95x30\n     Shrapnel: 1.5sec/150% Speed/35% Size\n     Reload: 3sec\n     Fire Rate: 0.95/sec\n     Range: 575m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is the ultimate ZD model that pushes the weapon's design to the absolute limit of current technology."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 5\n     Damage: 80x20\n     Shrapnel: 0.55sec/125% Speed/35% Size\n     Reload: 3sec\n     Fire Rate: 0.95/sec\n     Range: 575m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe 'Splendor' series of Limpet Launchers diverge from the normal high explosive varieties, instead opting for shrapnel based explosives.  Thanks to Ravager technology the shrapnel used is both capable of piercing all known Giant Insect carapaces and light enough to ricochet off walls.  The effect is particularly devastating in enclosed spaces making this the preferred Limpet launcher for underground missions, while remaining capable above ground as well.  Space has been made for a larger ammo capacity and a more efficient loading system keeps reload times roughly the same as the Gun series.  The more compact launcher system however takes longer to chamber each Limpet resulting in a lower fire rate.\n\nThis version is the ultimate ZD model that pushes the weapon's design to the absolute limit of current technology."
 	}
 }

--- a/examples/weapon/_Weapon623_Limpet-Sniper-ZD.json
+++ b/examples/weapon/_Weapon623_Limpet-Sniper-ZD.json
@@ -94,7 +94,7 @@
     {
       "type": "float",
       "name": "AmmoGravityFactor",
-      "value": 0
+      "value": 1
     },
     {
       "type": "float",
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 10
+      "value": 7
     },
     {
       "type": "ptr",

--- a/examples/weapon/_Weapon624_Limpet-Chain-Gun-ZD.json
+++ b/examples/weapon/_Weapon624_Limpet-Chain-Gun-ZD.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.9
+      "value": 1.5
     },
     {
       "type": "ptr",

--- a/examples/weapon/_eLimpetGun01_Limpet-Gun.json
+++ b/examples/weapon/_eLimpetGun01_Limpet-Gun.json
@@ -159,7 +159,7 @@
     {
       "type": "float",
       "name": "AmmoSpeed",
-      "value": 0.85
+      "value": 1.5
     },
     {
       "type": "ptr",
@@ -648,6 +648,6 @@
   ],
   "meta": {
     "id": "eLimpetGun01",
-    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 130.0\n     Blast Area: Radius 6.0m\n     Reload: 3.5sec\n     Fire Rate: 0.71/sec\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis version is a direct-to-manufacture model based on the original prototype.  While unrefined compared to later models, it is cheap to build enmass and has a proven record against the Giant Insects 8 years ago."
+    "description": "<font face=%dq%$FixedFont%dq% color=%dq%#ffffff%dq%>     Number: 3\n     Damage: 130.0\n     Blast Area: Radius 6.0m\n     Reload: 3.5sec\n     Fire Rate: 0.71/sec\n     Range: 450m\n<font face=%dq%$NormalFont%dq% color=%dq%#80c3f5%dq%>\nA specialised launcher that fires large sticky bombs known as 'Limpets' that can be remotely detonated with the secondary fire button.  The Limpets can also be defused without detonating by reloading the weapon.  Limpet Launchers supply a much needed burst of damage any Air Raider can appreciate when backed into a corner.\n\nThe Gun variety of Limpet launchers provides the baseline for the series' performance, characterised by low fire rates and long reload times compensated by high per shot damage and good blast radius.\n\nThis version is a direct-to-manufacture model based on the original prototype.  While unrefined compared to later models, it is cheap to build enmass and has a proven record against the Giant Insects 8 years ago."
   }
 }

--- a/rebalance/changes.txt
+++ b/rebalance/changes.txt
@@ -52,15 +52,20 @@ AIR RAIDER
   - Limpet Guns overhauled completely: Now much slower and shorter ranged but far more powerful per shot
   - All Limpet Guns can detonate without reloading.
   - All C-Bombs, Roller Bombs, and Beetles can detonate without reloading.
-  - Durability for Titan increased by 220% (from 110,400 to 353,280 for final model.)
+  - Durability for Titan increased by 200% (from 110,400 to 331,200 for final model.)
   - Titan starts 80% reloaded instead of 40%.
   - Requiem Gun projectile of Titan travels 200 times faster.
-  - Durability for Gigantus Tanks increased by 220% (from 25,000 to 80,000 for final model.)
-  - Durability for Armoured Railguns increased by 100% (from 30,000 to 60,000 for final model)
-  - Durability for Vegaulta powersuits increased by 260% (from 14,000 to 50,400 for Vegaulta Firelord.)
-  - Durability for Depth Crawlers increased by 430% (from 3750 to 19,875 for final model)
-  - Durability for all Ground Vehicles (except Bikes) increased by 290% (from 9,450 to 36,855 for final Grape model)
-  - Durability for all Helicopters increased by 320% (from 6,000 to 25,200 for final Brute model)
+  - Durability for all vehicles increased:
+		  - Gigantus Tanks increased by 200% (from 25,000 to 75,000 for final model.)
+		  - Armoured Railguns increased by 100% (from 30,000 to 60,000 for final model)
+		  - Vegalta Powersuits increased by 150% (from 20,000 to 50,000 for final model.)
+		  - Proteus Powersuits increased by 50% (from 165,000 to 247,500 for final model)
+		  - Depth Crawlers increased by 400% (from 3750 to 18,750 for final model)
+	  	- Grapes increased by 300% (from 9,450 to 37,800 for final model)
+		  - Caravans increased by 100% (from 33,000 to 66,000 for final model)
+		  - SDL1 Bikes increased by 100% (from 3,300 to 6,600 for final model)
+		  - Naeglings increased by 200% (from 6,600 to 19,800 for final model)
+		  - Helicopters increased by 300% (from 6,000 to 24,000 for final Brute model)
   - All support posts will reload in the background. (Not Life Vendor or guns.)
   - Reload time for Power Posts and Guard posts reduced by 50%.
   - Response time for Cannon (Artillery Squad) strikes reduced by 75%.

--- a/rebalance/rebalance.js
+++ b/rebalance/rebalance.js
@@ -583,48 +583,32 @@ rebalance({category: 36, name: /Titan/}, (template, i, meta, text) => {
     const vehicleParameters = summonParameters.value[3]
     const strengthParameters = vehicleParameters.value[0]
     const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 3.2
+    healthFactor.value *= 3
     return values
   })
   replaceText(text,
     /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 3.2}`
+    (match, hp) => `Durability: ${hp * 3}`
   )
 })
 
-rebalance({category: 36, name:/Gigantus/}, (template, i, meta, text) => {
+rebalance({category: 36, name: /Gigantus|Melt/}, (template, i, meta, text) => {
   // Increase durability of all normal tanks
   patch(template, 'Ammo_CustomParameter', values => {
     const summonParameters = values[4]
     const vehicleParameters = summonParameters.value[3]
     const strengthParameters = vehicleParameters.value[0]
     const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 3.2
+    healthFactor.value *= 3
     return values
   })
   replaceText(text,
     /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 3.2}`
+    (match, hp) => `Durability: ${hp * 3}`
   )
 })
 
-rebalance({category: 36, name:/Melt/}, (template, i, meta, text) => {
-  // Increase durability of all Melt tank variants
-  patch(template, 'Ammo_CustomParameter', values => {
-    const summonParameters = values[4]
-    const vehicleParameters = summonParameters.value[3]
-    const strengthParameters = vehicleParameters.value[0]
-    const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 3.2
-    return values
-  })
-  replaceText(text,
-    /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 3.2}`
-  )
-})
-
-rebalance({category: 36, name:/Armored Railgun/}, (template, i, meta, text) => {
+rebalance({category: 36, name: /Armored Railgun/}, (template, i, meta, text) => {
   // Increase durability of all Armored Railguns
   patch(template, 'Ammo_CustomParameter', values => {
     const summonParameters = values[4]
@@ -637,38 +621,6 @@ rebalance({category: 36, name:/Armored Railgun/}, (template, i, meta, text) => {
   replaceText(text,
     /Durability: (\d+)/,
     (match, hp) => `Durability: ${hp * 2}`
-  )
-})
-
-rebalance({category: 37}, (template, i, meta, text) => {
-  // Increase durability of all ground vehicles
-  patch(template, 'Ammo_CustomParameter', values => {
-    const summonParameters = values[4]
-    const vehicleParameters = summonParameters.value[3]
-    const strengthParameters = vehicleParameters.value[0]
-    const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 3.9
-    return values
-  })
-  replaceText(text,
-    /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 3.9}`
-  )
-})
-
-rebalance({category: 37, name: /SDL1/}, (template, i, meta, text) => {
-  // Returns the bikes to being squishy
-  patch(template, 'Ammo_CustomParameter', values => {
-    const summonParameters = values[4]
-    const vehicleParameters = summonParameters.value[3]
-    const strengthParameters = vehicleParameters.value[0]
-    const healthFactor = strengthParameters.value[0]
-    healthFactor.value /= 3.9
-    return values
-  })
-  replaceText(text,
-    /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp / 3.9}`
   )
 })
 
@@ -687,6 +639,22 @@ rebalance({category: 37, name: /SDL1/}, (template, i, meta, text) => {
     weight.value *= 1.5
     return values
   })
+})
+
+rebalance({category: 37, name: /SDL1/}, (template, i, meta, text) => {
+  // Increase durability of all Bikes
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 2
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 2}`
+  )
 })
 
 rebalance({category: 37, name: /Grape/}, (template, i, meta, text) => {
@@ -711,6 +679,54 @@ rebalance({category: 37, name: /Grape/}, (template, i, meta, text) => {
   })
 })
 
+rebalance({category: 37, name: /Grape/}, (template, i, meta, text) => {
+  // Increase durability of all Grape models
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 4
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 4}`
+  )
+})
+
+rebalance({category: 37, name: /Caravan/}, (template, i, meta, text) => {
+  // Increase durability of all Caravan models
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 2
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 2}`
+  )
+})
+
+rebalance({category: 37, name: /Naegling/}, (template, i, meta, text) => {
+  // Increase durability of all Unarmored Ground Vehicle models
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 3
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 3}`
+  )
+})
+
 rebalance({category: 38}, (template, i, meta, text) => {
   // Increase durability of all Helicopters
   patch(template, 'Ammo_CustomParameter', values => {
@@ -718,48 +734,60 @@ rebalance({category: 38}, (template, i, meta, text) => {
     const vehicleParameters = summonParameters.value[3]
     const strengthParameters = vehicleParameters.value[0]
     const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 4.2
+    healthFactor.value *= 4
     return values
   })
   replaceText(text,
     /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 4.2}`
+    (match, hp) => `Durability: ${hp * 4}`
   )
 })
 
-rebalance({category: 39, name:/BEGARUTA/}, (template, i, meta, text) => {
-  // Increase durability of all medium power suits
-  patch(template, 'Ammo_CustomParameter', values => {
-    const summonParameters = values[4]
-    const vehicleParameters = summonParameters.value[3]
-    const strengthParameters = vehicleParameters.value[0]
-    const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 3.6
-    return values
-  })
-  replaceText(text,
-    /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 3.6}`
-  )
-})
-
-rebalance({category: 39, /Depth-Crawler/}, (template, i, meta, text) => {
+rebalance({category: 39, name: /Depth Crawler/}, (template, i, meta, text) => {
   // Increase durability of all depth crawlers
   patch(template, 'Ammo_CustomParameter', values => {
     const summonParameters = values[4]
     const vehicleParameters = summonParameters.value[3]
     const strengthParameters = vehicleParameters.value[0]
     const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 5.3
+    healthFactor.value *= 5
     return values
   })
   replaceText(text,
     /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 5.3}`
+    (match, hp) => `Durability: ${hp * 5}`
   )
 })
 
+rebalance({category: 39, name:/Vegalta/}, (template, i, meta, text) => {
+  // Increase durability of all Vegalta power suits
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 4
+    return values
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 4}`
+  )
+})
 
+rebalance({category: 39, name:/Proteus/}, (template, i, meta, text) => {
+  // Increase durability of all Proteus power suits
+  patch(template, 'Ammo_CustomParameter', values => {
+    const summonParameters = values[4]
+    const vehicleParameters = summonParameters.value[3]
+    const strengthParameters = vehicleParameters.value[0]
+    const healthFactor = strengthParameters.value[0]
+    healthFactor.value *= 1.5
+  })
+  replaceText(text,
+    /Durability: (\d+)/,
+    (match, hp) => `Durability: ${hp * 1.5}`
+  )
 })
 
 function json(obj) {

--- a/rebalance/rebalance.js
+++ b/rebalance/rebalance.js
@@ -766,12 +766,12 @@ rebalance({category: 39, name:/Vegalta/}, (template, i, meta, text) => {
     const vehicleParameters = summonParameters.value[3]
     const strengthParameters = vehicleParameters.value[0]
     const healthFactor = strengthParameters.value[0]
-    healthFactor.value *= 4
+    healthFactor.value *= 2.5
     return values
   })
   replaceText(text,
     /Durability: (\d+)/,
-    (match, hp) => `Durability: ${hp * 4}`
+    (match, hp) => `Durability: ${hp * 2.5}`
   )
 })
 


### PR DESCRIPTION
Changed durability multipliers to apply to each vehicle group more specifically (such as separate multipliers for Grape and Caravan).  Also included multipliers for vehicles I missed the first time like the Proteus suits.

All limpet launchers (except snipers) had their projectile speed increased.  They might actually reach their Range limits now, and can reach things like Deroys standing near you where they couldn't before

Splendor Limpit launchers nerfed significantly: they had far too much AoE for the damage they dealt.  Both damage and AoE was reduced, it remains the wider ranged option for limpet guns but has worse single target.

Sniper limpet launchers had their projectile speed reduced and are now affected by gravity to make them harder to aim.

AoE of Chaingun and Shot limpet launchers (both splendor and normal) was reduced to compensate for their higher sDPS.